### PR TITLE
feat: Add package.json for Node.js build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "visualspends",
+  "version": "1.0.0",
+  "description": "SpendWise - Personal Spending Companion",
+  "main": "main.py",
+  "scripts": {
+    "build": "tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify",
+    "watch": "tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --watch"
+  },
+  "keywords": [
+    "flask",
+    "tailwind",
+    "spendwise",
+    "finance"
+  ],
+  "author": "SpendWise User (via AI Assistant)",
+  "license": "MIT",
+  "devDependencies": {
+    "tailwindcss": "^4.1.10",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.19"
+  }
+}


### PR DESCRIPTION
This commit introduces a `package.json` file to the project root. This file is essential for managing Node.js dependencies (specifically Tailwind CSS, PostCSS, and Autoprefixer as devDependencies) and defining build scripts.

The primary purpose of this addition is to facilitate deployments on platforms like Vercel, which can use this `package.json` to install the necessary tools and run the Tailwind CSS build command (`npm run build`) to correctly generate the `output.css` file needed for the application's UI.

The `package.json` includes:
- Project metadata.
- A `build` script: `tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify`
- A `watch` script for local development.
- devDependencies for `tailwindcss`, `postcss`, and `autoprefixer`.