### PR TITLE
fix: Use npx in npm scripts for Tailwind CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SpendWise - Personal Spending Companion",
   "main": "main.py",
   "scripts": {
-    "build": "tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify",
-    "watch": "tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --watch"
+    "build": "npx tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify",
+    "watch": "npx tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --watch"
   },
   "keywords": [
     "flask",


### PR DESCRIPTION
Updates the `build` and `watch` scripts in `package.json` to prepend `npx` to the `tailwindcss` command.

This change ensures that the Tailwind CSS CLI is correctly found and executed from the locally installed `node_modules/.bin` directory, which is crucial for reliable execution in CI/CD environments like Vercel that might not have `tailwindcss` available globally in the PATH.

This should resolve the 'tailwindcss: command not found' error during Vercel builds.