### PR TITLE
fix: Use direct path to tailwindcss executable in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "SpendWise - Personal Spending Companion",
   "main": "main.py",
   "scripts": {
-    "build": "npx tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify",
-    "watch": "npx tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --watch"
+    "build": "./node_modules/.bin/tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --minify",
+    "watch": "./node_modules/.bin/tailwindcss -i ./spendwise/static/css/input.css -o ./spendwise/static/css/output.css --watch"
   },
   "keywords": [
     "flask",


### PR DESCRIPTION
Updates the `build` and `watch` scripts in `package.json` to call the `tailwindcss` CLI using its direct path from `./node_modules/.bin/tailwindcss`.

This change is intended to resolve issues in CI/CD environments like Vercel where `npx tailwindcss` might fail with "could not determine executable to run". Using the direct path is a more robust way to ensure the locally installed Tailwind CSS executable is found and used during the build process.